### PR TITLE
Allow tx-comments from CLI

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -280,9 +280,9 @@ Value getaddressesbyaccount(const Array& params, bool fHelp)
 
 Value sendtoaddress(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 2 || params.size() > 4)
+    if (fHelp || params.size() < 2 || params.size() > 5)
         throw runtime_error(
-            "sendtoaddress <paccoinAddress> <amount> [comment] [comment-to]\n"
+            "sendtoaddress <paccoinAddress> <amount> [comment] [comment-to] [tx-comment]\n"
             "<amount> is a real and is rounded to the nearest 0.000001"
             + HelpRequiringPassphrase());
 


### PR DESCRIPTION
This change allows the user to attach a transaction comment from CLI by executing the following command:

`sendtoaddress <paccoinAddress> <amount> [comment] [comment-to] [tx-comment]`